### PR TITLE
Fix memory errors

### DIFF
--- a/packing.hpp
+++ b/packing.hpp
@@ -96,12 +96,11 @@ void unpackKmer(const unsigned char packed_kmer[PACKED_KMER_LEN], char* kmer) {
         packedCodeToFourMerCoded = true;
         init_LookupTable();
     }
-    int i = 0, j = 0;
-    for (; i < PACKED_KMER_LEN; i++, j += 4) {
+    for (int j = 0; j < PACKED_KMER_LEN; j++) {
         unsigned char block[4];
-        *(unsigned int*)block = packedCodeToFourMer[packed_kmer[i]];
-        for (int i = 0; i < 4; i++) {
-            (kmer + j)[i] = (char)block[i];
+        *(unsigned int*)block = packedCodeToFourMer[packed_kmer[j]];
+        for (int i = 0; i < 4 && i + (j << 2) < KMER_LEN; i++) {
+            (kmer + (j << 2))[i] = (char)block[i];
         }
     }
 }

--- a/read_kmers.hpp
+++ b/read_kmers.hpp
@@ -64,7 +64,7 @@ std::vector<kmer_pair> read_kmers(const std::string& fname, int nprocs = 1, int 
     const size_t line_len = KMER_LEN + 4;
     fseek(f, line_len * start, SEEK_SET);
 
-    std::shared_ptr<char> buf(new char[line_len * size]);
+    std::shared_ptr<char[]> buf(new char[line_len * size]);
     fread(buf.get(), sizeof(char), line_len * size, f);
 
     std::vector<kmer_pair> kmers;


### PR DESCRIPTION
This fixes a buffer overflow and a mismatch between `new[]` and `delete`. I believe that these bugs should be fixed because they are UB and they prevent students from getting a clean ASan report.

See commit messages for details.